### PR TITLE
Markers were not always resolved when block-helpers returned promise

### DIFF
--- a/index.js
+++ b/index.js
@@ -211,11 +211,11 @@ Markers.prototype.resolve = function resolve (input) {
          */
         function replacePlaceholdersRecursivelyIn (string) {
           return string.replace(self.regex, function (match, index, gt) {
-          // Check whether promise result must be escaped
-          var resolvedValue = promiseResults[index]
+            // Check whether promise result must be escaped
+            var resolvedValue = promiseResults[index]
             var result = gt === '>' ? resolvedValue : self.engine.escapeExpression(resolvedValue)
             return replacePlaceholdersRecursivelyIn(result)
-        })
+          })
         }
 
         // Promises are fulfilled. Insert real values into the result.

--- a/test/fixtures/async-block-helper-with-nested-async-helper.hbs
+++ b/test/fixtures/async-block-helper-with-nested-async-helper.hbs
@@ -1,0 +1,1 @@
+{{#block-context}}{{helper 10 'a'}}{{/block-context}}

--- a/test/main-spec.js
+++ b/test/main-spec.js
@@ -54,6 +54,9 @@ Handlebars.registerHelper({
         return 'bi(' + result + ')'
       })
   },
+  'block-context': function(options) {
+    return Q(options.fn(this))
+  },
   'insert-twice': function (options) {
     return options.fn(this) + ',' + options.fn(this)
   },
@@ -168,6 +171,12 @@ describe('promised-handlebars:', function () {
     var template = Handlebars.compile(fixture('block-helper-manipulate.hbs'))
     return expect(template({arr: [{a: 'aa'}, {a: 'bb'}]}))
       .to.eventually.equal('abc')
+      .notify(done)
+  })
+  it('async helpers should work inside an async block-helper that passes (this) to the block-function', function (done) {
+    var template = Handlebars.compile(fixture('async-block-helper-with-nested-async-helper.hbs'))
+    return expect(template({a:'b'}))
+      .to.eventually.equal('h(a)')
       .notify(done)
   })
 })

--- a/test/main-spec.js
+++ b/test/main-spec.js
@@ -54,7 +54,7 @@ Handlebars.registerHelper({
         return 'bi(' + result + ')'
       })
   },
-  'block-context': function(options) {
+  'block-context': function (options) {
     return Q(options.fn(this))
   },
   'insert-twice': function (options) {
@@ -175,7 +175,7 @@ describe('promised-handlebars:', function () {
   })
   it('async helpers should work inside an async block-helper that passes (this) to the block-function', function (done) {
     var template = Handlebars.compile(fixture('async-block-helper-with-nested-async-helper.hbs'))
-    return expect(template({a:'b'}))
+    return expect(template({a: 'b'}))
       .to.eventually.equal('h(a)')
       .notify(done)
   })


### PR DESCRIPTION
Fixes #7

Consider a block-helper returning a promise, which is called
without promise parameters and which contained async-helpers
in its body.
In this case, the "prepareAndResolveMarkers" function would not
create a new "Markers" instance and would not resolve the
markers created in the "options.fn(this)" call. The marker of
the inner helper would remain unresolved.
The solution is to replace markers recursively. When a replacement
text is substituted for a marker, if is recursively searched for
markers as well.