### PR TITLE
Revert to pre-refactoring wrapper of the `compile`-function and `regi…

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@ function promisedHandlebars (Handlebars, options) {
   engine.compile = wrap(engine.compile, function compileWrapper (oldCompile, args) {
     var fn = oldCompile.apply(engine, args)
     return wrap(fn, prepareAndResolveMarkers)
-    // Wrap the compiled function
+  // Wrap the compiled function
   })
 
   /**

--- a/test/main-spec.js
+++ b/test/main-spec.js
@@ -30,6 +30,10 @@ Handlebars.registerHelper({
       return 'h(' + value + ')'
     })
   },
+  'stringifyRoot': function (options) {
+    return JSON.stringify(options.data.root);
+  },
+
   'helper-hash': function (options) {
     var hashString = Object.keys(options.hash).sort().map(function (key) {
       return key + '=' + options.hash[key]
@@ -83,6 +87,7 @@ Handlebars.registerHelper('trim', function (options) {
 Handlebars.registerPartial('a', "{{helper '10' 'partialA'}}")
 Handlebars.registerPartial('b', "{{helper '10' 'partialB'}}")
 Handlebars.registerPartial('identity', 'id({{.}})')
+Handlebars.registerPartial('call', '{{{stringifyRoot}}}')
 
 describe('promised-handlebars:', function () {
   it('should return a promise for the ouput with helpers resolved', function (done) {
@@ -140,6 +145,16 @@ describe('promised-handlebars:', function () {
       .to.eventually.equal('index.js (1)\nondex.js (0)')
       .notify(done)
   })
+
+  it('partials calls should maintain the correct `root`-variable when a parameter is passed', function (done) {
+    var template = Handlebars.compile('{{>call a}}')
+    return expect(template({
+      a: 3
+    }))
+      .to.eventually.equal('{"a":3}')
+      .notify(done)
+  })
+
 
   it('helpers passed into partials as parameters like {{>partial (helper 123)}} should be resolved within the helper call', function (done) {
     var template = Handlebars.compile(fixture('helper-as-parameter-for-partial.hbs'))

--- a/test/main-spec.js
+++ b/test/main-spec.js
@@ -33,7 +33,6 @@ Handlebars.registerHelper({
   'stringifyRoot': function (options) {
     return JSON.stringify(options.data.root)
   },
-
   'helper-hash': function (options) {
     var hashString = Object.keys(options.hash).sort().map(function (key) {
       return key + '=' + options.hash[key]

--- a/test/main-spec.js
+++ b/test/main-spec.js
@@ -31,7 +31,7 @@ Handlebars.registerHelper({
     })
   },
   'stringifyRoot': function (options) {
-    return JSON.stringify(options.data.root);
+    return JSON.stringify(options.data.root)
   },
 
   'helper-hash': function (options) {
@@ -154,7 +154,6 @@ describe('promised-handlebars:', function () {
       .to.eventually.equal('{"a":3}')
       .notify(done)
   })
-
 
   it('helpers passed into partials as parameters like {{>partial (helper 123)}} should be resolved within the helper call', function (done) {
     var template = Handlebars.compile(fixture('helper-as-parameter-for-partial.hbs'))


### PR DESCRIPTION
…sterHelper`-function

Fixes #14

- The refactoring changed to wrapper to be more explicit for readability. The result was
  that not all options were passed to the partial.
- The fix is to use the old wrapping mechanism for these function (i.e. "wrap(...)" which
  passes "all" parameters to the wrapped function.