### PR TITLE
Support for Handlebars.SafeString

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,7 +63,7 @@ function promisedHandlebars (Handlebars, options) {
   engine.compile = wrap(engine.compile, function compileWrapper (oldCompile, args) {
     var fn = oldCompile.apply(engine, args)
     return wrap(fn, prepareAndResolveMarkers)
-  // Wrap the compiled function
+    // Wrap the compiled function
   })
 
   /**
@@ -218,6 +218,9 @@ Markers.prototype.resolve = function resolve (input) {
          * @returns {string}
          */
         function replacePlaceholdersRecursivelyIn (string) {
+          if (typeof string !== 'string') {
+            return string
+          }
           return string.replace(self.regex, function (match, index, gt) {
             // Check whether promise result must be escaped
             var resolvedValue = promiseResults[index]
@@ -286,6 +289,8 @@ function toArray (arrayLike) {
  * @returns {Boolean}     Whether it's a PromiseA like object
  */
 function isPromiseAlike (obj) {
-  if (obj == null) return false
+  if (obj == null) {
+    return false
+  }
   return (typeof obj === 'object') && (typeof obj.then === 'function')
 }

--- a/index.js
+++ b/index.js
@@ -8,7 +8,15 @@
 'use strict'
 
 var deepAplus = require('deep-aplus')
-var replaceP = require('./lib/replaceP')
+var createMarkers = require('./lib/markers')
+var utils = require('./lib/utils')
+
+// Basic utility functions
+var values = utils.values
+var wrap = utils.wrap
+var mapValues = utils.mapValues
+var anyApplies = utils.anyApplies
+var isPromiseAlike = utils.isPromiseAlike
 
 module.exports = promisedHandlebars
 
@@ -39,6 +47,7 @@ function promisedHandlebars (Handlebars, options) {
   }
 
   var deep = deepAplus(Promise)
+  var Markers = createMarkers(Promise)
 
   var engine = Handlebars.create()
   var markers = null
@@ -136,172 +145,3 @@ function promisedHandlebars (Handlebars, options) {
   return engine
 }
 
-/**
- * Wrap a function with a wrapper function
- * @param {function} fn the original function
- * @param {function(function,array)} wrapperFunction the wrapper-function
- *   receiving `fn` as first parameter and the arguments as second
- * @returns {function} a function that calls the wrapper with
- *   the original function and the arguments
- */
-function wrap (fn, wrapperFunction) {
-  return function () {
-    return wrapperFunction.call(this, fn, toArray(arguments))
-  }
-}
-
-/**
- * A class the handles the creation and resolution of markers in the Handlebars output.
- * Markes are used as placeholders in the output string for promises returned by helpers.
- * They are replaced as soon as the promises are resolved.
- * @param {Handlebars} engine a Handlebars instance (needed for the `escapeExpression` function)
- * @param {string} prefix the prefix to identify placeholders (this prefix should never occur in the template).
- * @constructor
- */
-function Markers (engine, prefix) {
-  /**
-   * This array stores the promises created in the current event-loop cycle
-   * @type {Promise[]}
-   */
-  this.promiseStore = []
-  this.engine = engine
-  this.prefix = prefix
-  // one line from substack's quotemeta-package
-  var placeHolderRegexEscaped = String(this.prefix).replace(/(\W)/g, '\\$1')
-  this.regex = new RegExp(placeHolderRegexEscaped + '(\\d+)(>|&gt;)', 'g')
-  this.replaceP = replaceP(engine.Promise)
-}
-
-/**
- * Add a promise the the store and return a placeholder.
- * A placeholder consists of
- * * The configured prefix (or \u0001), followed by
- * * the index in the array
- * * ">"
-
- * @param {Promise} promise the promise
- * @return {Promise} a new promise with a toString-method returning the placeholder
- */
-Markers.prototype.asMarker = function asMarker (promise) {
-  // The placeholder: "prefix" for identification, index of promise in the store for retrieval, '>' for escaping
-  var placeholder = this.prefix + this.promiseStore.length + '>'
-  // Create a new promise, don't modify the input
-  var result = this.engine.Promise.resolve(promise)
-  result.toString = function () {
-    return placeholder
-  }
-  this.promiseStore.push(promise)
-  return result
-}
-
-/**
- * Replace the placeholder found in a string by the resolved promise values.
- * The input may be Promise, in which case it will be resolved first.
- * Non-string values are returned directly since they cannot contain placeholders.
- * String values are search for placeholders, which are then replaced by their resolved values.
- * If the '>' part of the placeholder has been escaped (i.e. as '&gt;') the resolved value
- * will be escaped as well.
- *
- * @param {Promise<any>} input the string with placeholders
- * @return {Promise<string>} a promise for the string with resolved placeholders
- */
-Markers.prototype.resolve = function resolve (input) {
-  var self = this
-  return this.engine.Promise.resolve(input).then(function (output) {
-    if (typeof output !== 'string') {
-      // Make sure that non-string values (e.g. numbers) are not converted to a string.
-      return output
-    }
-    return self.engine.Promise.all(self.promiseStore)
-      .then(function (promiseResults) {
-        /**
-         * Replace placeholders in a string. Looks for placeholders
-         * in the replacement string recursively.
-         * @param {string|Promise|Handlebars.SafeString} string
-         * @returns {Promise<string>}
-         */
-        function replacePlaceholdersRecursivelyIn (string) {
-          if (isPromiseAlike(string)) {
-            return string.then(function (string) {
-              return replacePlaceholdersRecursivelyIn(string)
-            })
-          }
-          if (typeof string.toHTML === 'function' && string.string) {
-            // This is a Handlebars.SafeString or something like it
-            return replacePlaceholdersRecursivelyIn(string.string)
-          }
-
-          // Must be a string, or something that can be converted to a string
-          return self.replaceP(String(string), self.regex, function (match, index, gt) {
-            // Check whether promise result must be escaped
-            var resolvedValue = promiseResults[index]
-            var result = gt === '>' ? resolvedValue : self.engine.escapeExpression(resolvedValue)
-            return replacePlaceholdersRecursivelyIn(result)
-          })
-        }
-
-        // Promises are fulfilled. Insert real values into the result.
-        return replacePlaceholdersRecursivelyIn(output)
-      })
-  })
-}
-
-/**
- * Apply the mapFn to all values of the object and return a new object with the applied values
- * @param obj the input object
- * @param {function(any, string, object): any} mapFn the map function (receives the value, the key and the whole object as parameter)
- * @returns {object} an object with the same keys as the input object
- */
-function mapValues (obj, mapFn) {
-  return Object.keys(obj).reduce(function (result, key) {
-    result[key] = mapFn(obj[key], key, obj)
-    return result
-  }, {})
-}
-
-/**
- * Return the values of the object
- * @param {object} obj an object
- * @returns {Array} the values of the object
- */
-function values (obj) {
-  return Object.keys(obj).map(function (key) {
-    return obj[key]
-  })
-}
-
-/**
- * Check if the predicate is true for any element of the array
- * @param {Array} array
- * @param {function(any):boolean} predicate
- * @returns {boolean}
- */
-function anyApplies (array, predicate) {
-  for (var i = 0; i < array.length; i++) {
-    if (predicate(array[i])) {
-      return true
-    }
-  }
-  return false
-}
-
-/**
- * Convert arrayLike-objects (like 'arguments') to an array
- * @param arrayLike
- * @returns {Array.<T>}
- */
-function toArray (arrayLike) {
-  return Array.prototype.slice.call(arrayLike)
-}
-
-/**
- * Test an object to see if it is a Promise
- * @param   {Object}  obj The object to test
- * @returns {Boolean}     Whether it's a PromiseA like object
- */
-function isPromiseAlike (obj) {
-  if (obj == null) {
-    return false
-  }
-  return (typeof obj === 'object') && (typeof obj.then === 'function')
-}

--- a/lib/markers.js
+++ b/lib/markers.js
@@ -1,0 +1,117 @@
+/*!
+ * promised-handlebars <https://github.com/nknapp/promised-handlebars>
+ *
+ * Copyright (c) 2015 Nils Knappmeier.
+ * Released under the MIT license.
+ */
+
+'use strict'
+
+var isPromiseAlike = require('./utils').isPromiseAlike
+var createReplaceP = require('./replaceP')
+
+/**
+ * Returns a `Markers` constructor that uses a specific Promise constructor
+ * @param Promise a Promise constructor
+ * @return {Markers} the Markers class
+ */
+module.exports = function createMarkersClass (Promise) {
+  var replaceP = createReplaceP(Promise)
+
+  /**
+   * A class the handles the creation and resolution of markers in the Handlebars output.
+   * Markes are used as placeholders in the output string for promises returned by helpers.
+   * They are replaced as soon as the promises are resolved.
+   * @param {Handlebars} engine a Handlebars instance (needed for the `escapeExpression` function)
+   * @param {string} prefix the prefix to identify placeholders (this prefix should never occur in the template).
+   * @constructor
+   */
+  function Markers (engine, prefix) {
+    /**
+     * This array stores the promises created in the current event-loop cycle
+     * @type {Promise[]}
+     */
+    this.promiseStore = []
+    this.engine = engine
+    this.prefix = prefix
+    // one line from substack's quotemeta-package
+    var placeHolderRegexEscaped = String(this.prefix).replace(/(\W)/g, '\\$1')
+    this.regex = new RegExp(placeHolderRegexEscaped + '(\\d+)(>|&gt;)', 'g')
+  }
+
+  /**
+   * Add a promise the the store and return a placeholder.
+   * A placeholder consists of
+   * * The configured prefix (or \u0001), followed by
+   * * the index in the array
+   * * ">"
+
+   * @param {Promise} promise the promise
+   * @return {Promise} a new promise with a toString-method returning the placeholder
+   */
+  Markers.prototype.asMarker = function asMarker (promise) {
+    // The placeholder: "prefix" for identification, index of promise in the store for retrieval, '>' for escaping
+    var placeholder = this.prefix + this.promiseStore.length + '>'
+    // Create a new promise, don't modify the input
+    var result = Promise.resolve(promise)
+    result.toString = function () {
+      return placeholder
+    }
+    this.promiseStore.push(promise)
+    return result
+  }
+
+  /**
+   * Replace the placeholder found in a string by the resolved promise values.
+   * The input may be Promise, in which case it will be resolved first.
+   * Non-string values are returned directly since they cannot contain placeholders.
+   * String values are search for placeholders, which are then replaced by their resolved values.
+   * If the '>' part of the placeholder has been escaped (i.e. as '&gt;') the resolved value
+   * will be escaped as well.
+   *
+   * @param {Promise<any>} input the string with placeholders
+   * @return {Promise<string>} a promise for the string with resolved placeholders
+   */
+  Markers.prototype.resolve = function resolve (input) {
+    var self = this
+    return Promise.resolve(input).then(function (output) {
+      if (typeof output !== 'string') {
+        // Make sure that non-string values (e.g. numbers) are not converted to a string.
+        return output
+      }
+      return Promise.all(self.promiseStore)
+        .then(function (promiseResults) {
+          /**
+           * Replace placeholders in a string. Looks for placeholders
+           * in the replacement string recursively.
+           * @param {string|Promise|Handlebars.SafeString} string
+           * @returns {Promise<string>}
+           */
+          function replacePlaceholdersRecursivelyIn (string) {
+            if (isPromiseAlike(string)) {
+              return string.then(function (string) {
+                return replacePlaceholdersRecursivelyIn(string)
+              })
+            }
+            if (typeof string.toHTML === 'function' && string.string) {
+              // This is a Handlebars.SafeString or something like it
+              return replacePlaceholdersRecursivelyIn(string.string)
+            }
+
+            // Must be a string, or something that can be converted to a string
+            return replaceP(String(string), self.regex, function (match, index, gt) {
+              // Check whether promise result must be escaped
+              var resolvedValue = promiseResults[ index ]
+              var result = gt === '>' ? resolvedValue : self.engine.escapeExpression(resolvedValue)
+              return replacePlaceholdersRecursivelyIn(result)
+            })
+          }
+
+          // Promises are fulfilled. Insert real values into the result.
+          return replacePlaceholdersRecursivelyIn(output)
+        })
+    })
+  }
+
+  return Markers
+}

--- a/lib/replaceP.js
+++ b/lib/replaceP.js
@@ -6,19 +6,22 @@
  */
 
 /**
+ * Creates a String.prototype.replace function with support for Promises using a specific Promise constructor.
  *
- * @param {Promise} Promise a Promise constructor
+ * @param {function(new:Promise)} Promise a promise constructor
  * @returns {function(string, RegExp, function)} an equivalent for String.prototype.replace which
  *  can handle promises
  */
 module.exports = function (Promise) {
   var deepAPlus = require('deep-aplus')(Promise)
   /**
+   * Similar to String.prototype.replace, but it returns a promise instead of a string
+   * and it can handle promises returned by the replacer
    *
-   * @param {string} string
-   * @param {RegExp} regex
-   * @param {function|string} replaceer
-   * @return {Promise<string>} a promise for the replaced string
+   * @param {string} string the source string
+   * @param {RegExp} regex the part/pattern to be replaced
+   * @param {function(string, string..., number, string):(Promise<string>|string)|string} replacer the replacement function or string
+   * @return {Promise<string>} a promise the resolves to the replaced string
    */
   return function replaceP (string, regex, replacer) {
     if (typeof replacer === 'string') {

--- a/lib/replaceP.js
+++ b/lib/replaceP.js
@@ -5,6 +5,8 @@
  * Released under the MIT license.
  */
 
+'use strict'
+
 /**
  * Creates a String.prototype.replace function with support for Promises using a specific Promise constructor.
  *
@@ -12,7 +14,7 @@
  * @returns {function(string, RegExp, function)} an equivalent for String.prototype.replace which
  *  can handle promises
  */
-module.exports = function (Promise) {
+module.exports = function createReplaceP(Promise) {
   var deepAPlus = require('deep-aplus')(Promise)
   /**
    * Similar to String.prototype.replace, but it returns a promise instead of a string

--- a/lib/replaceP.js
+++ b/lib/replaceP.js
@@ -1,0 +1,59 @@
+/*!
+ * promised-handlebars <https://github.com/nknapp/promised-handlebars>
+ *
+ * Copyright (c) 2015 Nils Knappmeier.
+ * Released under the MIT license.
+ */
+
+/**
+ *
+ * @param {Promise} Promise a Promise constructor
+ * @returns {function(string, RegExp, function)} an equivalent for String.prototype.replace which
+ *  can handle promises
+ */
+module.exports = function (Promise) {
+  var deepAPlus = require('deep-aplus')(Promise)
+  /**
+   *
+   * @param {string} string
+   * @param {RegExp} regex
+   * @param {function|string} replaceer
+   * @return {Promise<string>} a promise for the replaced string
+   */
+  return function replaceP (string, regex, replacer) {
+    if (typeof replacer === 'string') {
+      return Promise.resolve(string.replace(regex, replacer))
+    }
+    if (typeof replacer === 'function') {
+      var parts = []
+      var lastIndex = 0
+
+      // Use "replace" just to iterate all matches conveniently
+      string.replace(regex, function () {
+        var replacerArgs = Array.prototype.slice.apply(arguments)
+        var offset = replacerArgs[replacerArgs.length - 2] // prior to last argument is the offset
+
+        // From last match (or start) up to next match
+        parts.push(string.substr(lastIndex, offset - lastIndex))
+
+        var replacementP = deepAPlus(replacer.apply(this, replacerArgs))
+          .then(function (replacement) {
+            return String(replacement)
+          })
+
+        // Next match
+        parts.push(replacementP)
+
+        // Prepare next iteration (switch to first character after match)
+        lastIndex = offset + replacerArgs[0].length
+      })
+
+      // Last match up to end
+      parts.push(string.substr(lastIndex))
+
+      return Promise.all(parts).then(function (resolvedParts) {
+        return resolvedParts.join('')
+      })
+    }
+  }
+}

--- a/lib/replaceP.js
+++ b/lib/replaceP.js
@@ -14,7 +14,7 @@
  * @returns {function(string, RegExp, function)} an equivalent for String.prototype.replace which
  *  can handle promises
  */
-module.exports = function createReplaceP(Promise) {
+module.exports = function createReplaceP (Promise) {
   var deepAPlus = require('deep-aplus')(Promise)
   /**
    * Similar to String.prototype.replace, but it returns a promise instead of a string

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,91 @@
+/*!
+ * promised-handlebars <https://github.com/nknapp/promised-handlebars>
+ *
+ * Copyright (c) 2015 Nils Knappmeier.
+ * Released under the MIT license.
+ */
+
+'use strict'
+
+module.exports = {
+  wrap: wrap,
+  mapValues: mapValues,
+  values: values,
+  anyApplies: anyApplies,
+  toArray: toArray,
+  isPromiseAlike: isPromiseAlike
+}
+
+/**
+ * Wrap a function with a wrapper function
+ * @param {function} fn the original function
+ * @param {function(function,array)} wrapperFunction the wrapper-function
+ *   receiving `fn` as first parameter and the arguments as second
+ * @returns {function} a function that calls the wrapper with
+ *   the original function and the arguments
+ */
+function wrap (fn, wrapperFunction) {
+  return function () {
+    return wrapperFunction.call(this, fn, toArray(arguments))
+  }
+}
+
+/**
+ * Apply the mapFn to all values of the object and return a new object with the applied values
+ * @param obj the input object
+ * @param {function(any, string, object): any} mapFn the map function (receives the value, the key and the whole object as parameter)
+ * @returns {object} an object with the same keys as the input object
+ */
+function mapValues (obj, mapFn) {
+  return Object.keys(obj).reduce(function (result, key) {
+    result[key] = mapFn(obj[key], key, obj)
+    return result
+  }, {})
+}
+
+/**
+ * Return the values of the object
+ * @param {object} obj an object
+ * @returns {Array} the values of the object
+ */
+function values (obj) {
+  return Object.keys(obj).map(function (key) {
+    return obj[key]
+  })
+}
+
+/**
+ * Check if the predicate is true for any element of the array
+ * @param {Array} array
+ * @param {function(any):boolean} predicate
+ * @returns {boolean}
+ */
+function anyApplies (array, predicate) {
+  for (var i = 0; i < array.length; i++) {
+    if (predicate(array[i])) {
+      return true
+    }
+  }
+  return false
+}
+
+/**
+ * Convert arrayLike-objects (like 'arguments') to an array
+ * @param arrayLike
+ * @returns {Array.<T>}
+ */
+function toArray (arrayLike) {
+  return Array.prototype.slice.call(arrayLike)
+}
+
+/**
+ * Test an object to see if it is a Promise
+ * @param   {Object}  obj The object to test
+ * @returns {Boolean}     Whether it's a PromiseA like object
+ */
+function isPromiseAlike (obj) {
+  if (obj == null) {
+    return false
+  }
+  return (typeof obj === 'object') && (typeof obj.then === 'function')
+}

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "q"
   ],
   "files": [
-    "index.js"
+    "index.js",
+    "lib"
   ],
   "devDependencies": {
     "q": "^1.4.1",

--- a/test/default-suite.js
+++ b/test/default-suite.js
@@ -115,10 +115,17 @@ function runDefaultSuite () {
       .notify(done)
   })
 
-  it('should handle promises with Handlebars.SafeString correctly', function (done) {
-    var template = this.Handlebars.compile('abc{{#safeString}}abc{{/safeString}}')
+  it('should handle block helpers returning promises with Handlebars.SafeString correctly', function (done) {
+    var template = this.Handlebars.compile('abc{{#safeStringBlock}}<abc>{{/safeStringBlock}}')
     return expect(template({}))
-      .to.eventually.equal('abcabc')
+      .to.eventually.equal('abc<abc>')
+      .notify(done)
+  })
+
+  it('should handle helpers returning promises with Handlebars.SafeString correctly', function (done) {
+    var template = this.Handlebars.compile('abc{{safeString}}')
+    return expect(template({}))
+      .to.eventually.equal('abc<abc>')
       .notify(done)
   })
 }
@@ -176,9 +183,14 @@ function setupHandlebars (Handlebars) {
     'spaces': function (count) {
       return '                                              '.substr(0, count)
     },
-    'safeString': function (options) {
+    'safeStringBlock': function (options) {
       return promisedDelay(100).then(function () {
         return new Handlebars.SafeString(options.fn(this))
+      })
+    },
+    'safeString': function () {
+      return promisedDelay(100).then(function () {
+        return new Handlebars.SafeString('<abc>')
       })
     }
   })

--- a/test/default-suite.js
+++ b/test/default-suite.js
@@ -33,6 +33,13 @@ function runDefaultSuite () {
       .notify(done)
   })
 
+  it('should handle null and undefined arguments of helpers', function (done) {
+    var template = this.Handlebars.compile(fixture('simple-helper.hbs'))
+    return expect(template({a: null, b: undefined}))
+      .to.eventually.equal('123 h(null) 456 h(undefined)')
+      .notify(done)
+  })
+
   it('should work with block helpers that call `fn` while resolving a promise', function (done) {
     var template = this.Handlebars.compile(fixture('block-helper.hbs'))
     return expect(template({a: 'abc', b: 'xyz'}))

--- a/test/default-suite.js
+++ b/test/default-suite.js
@@ -114,6 +114,13 @@ function runDefaultSuite () {
       .to.eventually.equal('abc')
       .notify(done)
   })
+
+  it('should handle promises with Handlebars.SafeString correctly', function (done) {
+    var template = this.Handlebars.compile('{{#safeString}}abc{{/safeString}}')
+    return expect(template({}))
+      .to.eventually.equal('30')
+      .notify(done)
+  })
 }
 
 // Setup Handlebars helpers and partials
@@ -168,6 +175,11 @@ function setupHandlebars (Handlebars) {
     },
     'spaces': function (count) {
       return '                                              '.substr(0, count)
+    },
+    'safeString': function (options) {
+      return promisedDelay(100).then(function () {
+        return new Handlebars.SafeString(options.fn(this))
+      })
     }
   })
 

--- a/test/default-suite.js
+++ b/test/default-suite.js
@@ -116,9 +116,9 @@ function runDefaultSuite () {
   })
 
   it('should handle promises with Handlebars.SafeString correctly', function (done) {
-    var template = this.Handlebars.compile('{{#safeString}}abc{{/safeString}}')
+    var template = this.Handlebars.compile('abc{{#safeString}}abc{{/safeString}}')
     return expect(template({}))
-      .to.eventually.equal('30')
+      .to.eventually.equal('abcabc')
       .notify(done)
   })
 }

--- a/test/replaceP-spec.js
+++ b/test/replaceP-spec.js
@@ -1,0 +1,51 @@
+/*!
+ * promised-handlebars <https://github.com/nknapp/promised-handlebars>
+ *
+ * Copyright (c) 2015 Nils Knappmeier.
+ * Released under the MIT license.
+ */
+
+// /* global after */
+// /* global before */
+/* global describe */
+// /* global xdescribe */
+/* global it */
+
+'use strict'
+
+var replaceP = require('../lib/replaceP')(require('bluebird'))
+var chai = require('chai')
+var chaiAsPromised = require('chai-as-promised')
+chai.use(chaiAsPromised)
+var expect = chai.expect
+
+describe('replaceP: ', function () {
+  it('should behave like String.prototype.replace for string replacements', function () {
+    return expect(replaceP('abcde', /([bd])./g, '$1x')).to.eventually.equal('abxdx')
+  })
+
+  it('should behave like String.prototype.replace for functions returning strings', function () {
+    function replacer (match, p1, offset, string) {
+      expect(string).to.equal('abcdef')
+      return match + '(' + p1 + ',' + offset + ')'
+    }
+
+    // Check fixture againt String.prototype.replace to make sure the test is correct
+    expect('abcdef'.replace(/([bd])./g, replacer)).to.equal('abc(b,1)de(d,3)f')
+    // Actual "expect"
+    return expect(replaceP('abcdef', /([bd])./g, replacer)).to.eventually.equal('abc(b,1)de(d,3)f')
+  })
+
+  it('should be able to handle promises returned by the replacer', function () {
+    function replacer (match, p1, offset, string) {
+      expect(string).to.equal('abcdef')
+      return new Promise(function (resolve, reject) {
+        setTimeout(function () {
+          resolve(match + '(' + p1 + ',' + offset + ')')
+        }, 10)
+      })
+    }
+
+    return expect(replaceP('abcdef', /([bd])./g, replacer)).to.eventually.equal('abc(b,1)de(d,3)f')
+  })
+})

--- a/test/replaceP-spec.js
+++ b/test/replaceP-spec.js
@@ -16,6 +16,7 @@
 var replaceP = require('../lib/replaceP')(require('bluebird'))
 var chai = require('chai')
 var chaiAsPromised = require('chai-as-promised')
+var Q = require('q')
 chai.use(chaiAsPromised)
 var expect = chai.expect
 
@@ -39,13 +40,11 @@ describe('replaceP: ', function () {
   it('should be able to handle promises returned by the replacer', function () {
     function replacer (match, p1, offset, string) {
       expect(string).to.equal('abcdef')
-      return new Promise(function (resolve, reject) {
-        setTimeout(function () {
-          resolve(match + '(' + p1 + ',' + offset + ')')
-        }, 10)
-      })
+      return Q.delay(10)
+        .then(function () {
+          return match + '(' + p1 + ',' + offset + ')'
+        })
     }
-
     return expect(replaceP('abcdef', /([bd])./g, replacer)).to.eventually.equal('abc(b,1)de(d,3)f')
   })
 })


### PR DESCRIPTION
This PR solves #25. `promisedHandlebars` eturns the correct result for a test-case derived from the one in #22).
It would be nice if someone could review this and give comments. If nobody says a word, I will merge and publish  next week (probably on Tuesday) to give some time for reviews.

Basically, the solution is to implement special behavior for Promises and SafeStrings in the `replacePlaceholdersRecursivelyIn`-function. This also caused the need for a `String.prototype.replace`-alternative that is capable for handling Promises returned from the replacer-function.
This is implemented in a separate file (and could possibly be extracted into a separate npm-module).

