### PR TITLE
preserve original synchronous compile function as compileSync

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,6 +69,9 @@ function promisedHandlebars (Handlebars, options) {
   // Re-register all built-in-helpers to ensure that their methods are wrapped
   engine.registerHelper(engine.helpers)
 
+  // Preserve synchronous 'compile' function
+  engine.compileSync = engine.compile.bind({})
+
   // Wrap the `compile` function, so that it wraps the compiled-template
   // with `prepareAndResolveMarkers`
   engine.compile = wrap(engine.compile, function compileWrapper (oldCompile, args) {


### PR DESCRIPTION
I have tens of tests for handlebars helpers and having `compileSync` function makes it easier to test them. Other than that it just seems like a nice idea to preserve the original synchronous function.