### PR TITLE
added support for template function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ tmp
 # Another files #
 # ###############
 Icon?
+.idea/
 .DS_Store*
 Thumbs.db
 ehthumbs.db

--- a/index.js
+++ b/index.js
@@ -73,7 +73,15 @@ function promisedHandlebars (Handlebars, options) {
   // with `prepareAndResolveMarkers`
   engine.compile = wrap(engine.compile, function compileWrapper (oldCompile, args) {
     var fn = oldCompile.apply(engine, args)
+    return wrap(fn, prepareAndResolveMarkers)
     // Wrap the compiled function
+  })
+
+  // Wrap the `template` function, so that it wraps the precompiled template
+  // with `prepareAndResolveMarkers`
+  engine.template = wrap(engine.template, function compileWrapper (oldTemplate, args) {
+    var fn = oldTemplate.apply(engine, args);
+
     return wrap(fn, prepareAndResolveMarkers)
   })
 
@@ -144,3 +152,4 @@ function promisedHandlebars (Handlebars, options) {
 
   return engine
 }
+


### PR DESCRIPTION
Hi

Idea: there usage of precompiled templates in the browser it is quite common. In order to make it work one needs to wrap the `template` function that it works in the same way `compile` does but for the precompiled template.

I know, the guidelines are not followed and I do not expect it to be merged as is, however this might be useful for the ones who is searching for the solution. I simply do not have time for this.